### PR TITLE
use exactly one and a half the keep alive value when setting read deadline

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -166,5 +166,10 @@ func HandleDisconnect(c *MQTTConn) {
 func (c *MQTTConn) resetReadDeadline() {
 	// We set Deadline to one and a half the MQTTConn keep alive value.
 	// This value could be user given or the server's default value.
-	c.Conn.SetReadDeadline(time.Now().Add(time.Second * time.Duration(c.KeepAlive+(c.KeepAlive/2))))
+	keepAlive := time.Second * time.Duration(c.KeepAlive + c.KeepAlive / 2)
+	if c.KeepAlive % 2 == 1 {
+		// add half a second
+		keepAlive += time.Millisecond * time.Duration(500)
+	}
+	c.Conn.SetReadDeadline(time.Now().Add(keepAlive))
 }

--- a/gopigeon_test.go
+++ b/gopigeon_test.go
@@ -64,9 +64,8 @@ func TestKeepAlive(t *testing.T) {
 		willFail  bool
 	}{
 		"not going over default keep alive time": {0, 0, false},
-		"not going over given keep alive time":   {2, 1, false},
+		"not going over given keep alive time":   {3, 1, false},
 		"going over default keep alive time":     {0, 3, true},
-		"going over given keep alive time":       {2, 5, true},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
use exactly one and a half the keep alive value when setting read deadline